### PR TITLE
Fix trace hierarchy

### DIFF
--- a/cmd/attractions/main.go
+++ b/cmd/attractions/main.go
@@ -65,7 +65,7 @@ func main() {
 	flag.Parse()
 
 	log.Info().Msgf("Initializing jaeger agent [service name: %v | host: %v]...", "attractions", *jaegeraddr)
-	tracer, _, err := oteltracing.Init("attractions", *jaegeraddr)
+	tracer, tp, err := oteltracing.Init("attractions", *jaegeraddr)
 	if err != nil {
 		log.Panic().Msgf("Got error while initializing jaeger agent: %v", err)
 	}
@@ -80,7 +80,8 @@ func main() {
 	log.Info().Msg("Consul agent initialized")
 
 	srv := attractions.Server{
-		Tracer: tracer,
+		Tracer:         tracer,
+		TracerProvider: tp,
 		// Port:     *port,
 		Registry:    registry,
 		Port:        serv_port,

--- a/services/attractions/server.go
+++ b/services/attractions/server.go
@@ -6,18 +6,19 @@ import (
 	"net"
 	"time"
 
-	"hotelReservation/registry"
-	pb "hotelReservation/services/attractions/proto"
-	"hotelReservation/tls"
 	"github.com/google/uuid"
 	"github.com/hailocab/go-geoindex"
 	"github.com/rs/zerolog/log"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
+	"hotelReservation/registry"
+	pb "hotelReservation/services/attractions/proto"
+	"hotelReservation/tls"
 )
 
 const (
@@ -36,11 +37,12 @@ type Server struct {
 	indexC *geoindex.ClusteringIndex
 	uuid   string
 
-	Registry    *registry.Client
-	Tracer      trace.Tracer
-	Port        int
-	IpAddr      string
-	MongoClient *mongo.Client
+	Registry       *registry.Client
+	Tracer         trace.Tracer
+	TracerProvider trace.TracerProvider
+	Port           int
+	IpAddr         string
+	MongoClient    *mongo.Client
 }
 
 // Run starts the server
@@ -75,7 +77,10 @@ func (s *Server) Run() error {
 			PermitWithoutStream: true,
 		}),
 		grpc.UnaryInterceptor(
-			otelgrpc.UnaryServerInterceptor(),
+			otelgrpc.UnaryServerInterceptor(
+				otelgrpc.WithTracerProvider(s.TracerProvider),
+				otelgrpc.WithPropagators(otel.GetTextMapPropagator()),
+			),
 		),
 	}
 

--- a/services/profile/server.go
+++ b/services/profile/server.go
@@ -9,17 +9,18 @@ import (
 	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
-	"hotelReservation/registry"
-	pb "hotelReservation/services/profile/proto"
-	"hotelReservation/tls"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
+	"hotelReservation/registry"
+	pb "hotelReservation/services/profile/proto"
+	"hotelReservation/tls"
 )
 
 const name = "srv-profile"
@@ -30,13 +31,13 @@ type Server struct {
 
 	uuid string
 
-	Tracer      trace.Tracer
+	Tracer         trace.Tracer
 	TracerProvider trace.TracerProvider
-	Port        int
-	IpAddr      string
-	MongoClient *mongo.Client
-	Registry    *registry.Client
-	MemcClient  *memcache.Client
+	Port           int
+	IpAddr         string
+	MongoClient    *mongo.Client
+	Registry       *registry.Client
+	MemcClient     *memcache.Client
 }
 
 // Run starts the server
@@ -58,7 +59,10 @@ func (s *Server) Run() error {
 			PermitWithoutStream: true,
 		}),
 		grpc.UnaryInterceptor(
-			otelgrpc.UnaryServerInterceptor(),
+			otelgrpc.UnaryServerInterceptor(
+				otelgrpc.WithTracerProvider(s.TracerProvider),
+				otelgrpc.WithPropagators(otel.GetTextMapPropagator()),
+			),
 		),
 	}
 

--- a/services/reservation/server.go
+++ b/services/reservation/server.go
@@ -10,17 +10,18 @@ import (
 	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
-	"hotelReservation/registry"
-	pb "hotelReservation/services/reservation/proto"
-	"hotelReservation/tls"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
+	"hotelReservation/registry"
+	pb "hotelReservation/services/reservation/proto"
+	"hotelReservation/tls"
 )
 
 const name = "srv-reservation"
@@ -31,13 +32,13 @@ type Server struct {
 
 	uuid string
 
-	Tracer      trace.Tracer
+	Tracer         trace.Tracer
 	TracerProvider trace.TracerProvider
-	Port        int
-	IpAddr      string
-	MongoClient *mongo.Client
-	Registry    *registry.Client
-	MemcClient  *memcache.Client
+	Port           int
+	IpAddr         string
+	MongoClient    *mongo.Client
+	Registry       *registry.Client
+	MemcClient     *memcache.Client
 }
 
 // Run starts the server
@@ -57,7 +58,10 @@ func (s *Server) Run() error {
 			PermitWithoutStream: true,
 		}),
 		grpc.UnaryInterceptor(
-			otelgrpc.UnaryServerInterceptor(),
+			otelgrpc.UnaryServerInterceptor(
+				otelgrpc.WithTracerProvider(s.TracerProvider),
+				otelgrpc.WithPropagators(otel.GetTextMapPropagator()),
+			),
 		),
 	}
 


### PR DESCRIPTION
## Summary
- propagate tracing context across gRPC calls by setting tracer providers for otelgrpc interceptors
- ensure dialer injects context using global tracer provider
- pass tracer provider to attractions service

## Testing
- `go vet ./...` *(fails: Msgf call has arguments but no formatting directives)*
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_68495773aaf4832493205a63f6b39227