### PR TITLE
Fix dialer context propagation

### DIFF
--- a/cmd/attractions/main.go
+++ b/cmd/attractions/main.go
@@ -65,7 +65,7 @@ func main() {
 	flag.Parse()
 
 	log.Info().Msgf("Initializing jaeger agent [service name: %v | host: %v]...", "attractions", *jaegeraddr)
-	tracer, _, err := oteltracing.Init("attractions", *jaegeraddr)
+	tracer, tp, err := oteltracing.Init("attractions", *jaegeraddr)
 	if err != nil {
 		log.Panic().Msgf("Got error while initializing jaeger agent: %v", err)
 	}
@@ -80,7 +80,8 @@ func main() {
 	log.Info().Msg("Consul agent initialized")
 
 	srv := attractions.Server{
-		Tracer: tracer,
+		Tracer:         tracer,
+		TracerProvider: tp,
 		// Port:     *port,
 		Registry:    registry,
 		Port:        serv_port,

--- a/dialer/dialer.go
+++ b/dialer/dialer.go
@@ -7,27 +7,48 @@ import (
 
 	// "hotelReservation/tls"
 	consul "github.com/hashicorp/consul/api"
-	"google.golang.org/grpc/credentials/insecure"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	// "google.golang.org/grpc/keepalive"
 )
 
 // DialOption allows optional config for dialer
-type DialOption func(name string) (grpc.DialOption, error)
+// DialOption configures the gRPC dialer.
+type DialOption func(cfg *dialOptions) error
 
-// WithTracer traces rpc calls
-func WithTracer(tracer trace.Tracer) DialOption {
-    return func(name string) (grpc.DialOption, error) {
-        return grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()), nil
-    }
+type dialOptions struct {
+	dialopts []grpc.DialOption
+	unary    []grpc.UnaryClientInterceptor
+	stream   []grpc.StreamClientInterceptor
+}
+
+// WithTracerProvider configures tracing for grpc clients.
+func WithTracerProvider(tp trace.TracerProvider) DialOption {
+	return func(cfg *dialOptions) error {
+		cfg.unary = append(cfg.unary,
+			otelgrpc.UnaryClientInterceptor(
+				otelgrpc.WithTracerProvider(tp),
+				otelgrpc.WithPropagators(otel.GetTextMapPropagator()),
+			))
+		cfg.stream = append(cfg.stream,
+			otelgrpc.StreamClientInterceptor(
+				otelgrpc.WithTracerProvider(tp),
+				otelgrpc.WithPropagators(otel.GetTextMapPropagator()),
+			))
+		return nil
+	}
 }
 
 // WithBalancer enables client side load balancing
 func WithBalancer(registry *consul.Client) DialOption {
-	return func(name string) (grpc.DialOption, error) {
-		return grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin":{}}]}`), nil
+	return func(cfg *dialOptions) error {
+		cfg.dialopts = append(cfg.dialopts,
+			grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin":{}}]}`),
+		)
+		return nil
 	}
 }
 
@@ -62,11 +83,40 @@ func Dial(name string, ctx context.Context, opts ...DialOption) (*grpc.ClientCon
 	// return conn, nil
 	ctx, cancel := context.WithTimeout(ctx, time.Second*3)
 	defer cancel()
-	conn, err := grpc.DialContext(ctx, name,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
-		grpc.WithStreamInterceptor(otelgrpc.StreamClientInterceptor()),
+
+	cfg := dialOptions{
+		dialopts: []grpc.DialOption{
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		},
+	}
+
+	for _, fn := range opts {
+		if err := fn(&cfg); err != nil {
+			return nil, fmt.Errorf("config error: %v", err)
+		}
+	}
+
+	if len(cfg.unary) == 0 {
+		cfg.unary = append(cfg.unary,
+			otelgrpc.UnaryClientInterceptor(
+				otelgrpc.WithTracerProvider(otel.GetTracerProvider()),
+				otelgrpc.WithPropagators(otel.GetTextMapPropagator()),
+			))
+		cfg.stream = append(cfg.stream,
+			otelgrpc.StreamClientInterceptor(
+				otelgrpc.WithTracerProvider(otel.GetTracerProvider()),
+				otelgrpc.WithPropagators(otel.GetTextMapPropagator()),
+			))
+	}
+
+	cfg.dialopts = append(cfg.dialopts,
+		grpc.WithChainUnaryInterceptor(cfg.unary...),
+		grpc.WithChainStreamInterceptor(cfg.stream...),
 	)
+
+	dialopts := cfg.dialopts
+
+	conn, err := grpc.DialContext(ctx, name, dialopts...)
 	if err != nil {
 		return nil, fmt.Errorf("config error: %v", err)
 	}

--- a/services/attractions/server.go
+++ b/services/attractions/server.go
@@ -6,18 +6,19 @@ import (
 	"net"
 	"time"
 
-	"hotelReservation/registry"
-	pb "hotelReservation/services/attractions/proto"
-	"hotelReservation/tls"
 	"github.com/google/uuid"
 	"github.com/hailocab/go-geoindex"
 	"github.com/rs/zerolog/log"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
+	"hotelReservation/registry"
+	pb "hotelReservation/services/attractions/proto"
+	"hotelReservation/tls"
 )
 
 const (
@@ -36,11 +37,12 @@ type Server struct {
 	indexC *geoindex.ClusteringIndex
 	uuid   string
 
-	Registry    *registry.Client
-	Tracer      trace.Tracer
-	Port        int
-	IpAddr      string
-	MongoClient *mongo.Client
+	Registry       *registry.Client
+	Tracer         trace.Tracer
+	TracerProvider trace.TracerProvider
+	Port           int
+	IpAddr         string
+	MongoClient    *mongo.Client
 }
 
 // Run starts the server
@@ -75,7 +77,10 @@ func (s *Server) Run() error {
 			PermitWithoutStream: true,
 		}),
 		grpc.UnaryInterceptor(
-			otelgrpc.UnaryServerInterceptor(),
+			otelgrpc.UnaryServerInterceptor(
+				otelgrpc.WithTracerProvider(s.TracerProvider),
+				otelgrpc.WithPropagators(otel.GetTextMapPropagator()),
+			),
 		),
 	}
 

--- a/services/profile/server.go
+++ b/services/profile/server.go
@@ -9,17 +9,18 @@ import (
 	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
-	"hotelReservation/registry"
-	pb "hotelReservation/services/profile/proto"
-	"hotelReservation/tls"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
+	"hotelReservation/registry"
+	pb "hotelReservation/services/profile/proto"
+	"hotelReservation/tls"
 )
 
 const name = "srv-profile"
@@ -30,13 +31,13 @@ type Server struct {
 
 	uuid string
 
-	Tracer      trace.Tracer
+	Tracer         trace.Tracer
 	TracerProvider trace.TracerProvider
-	Port        int
-	IpAddr      string
-	MongoClient *mongo.Client
-	Registry    *registry.Client
-	MemcClient  *memcache.Client
+	Port           int
+	IpAddr         string
+	MongoClient    *mongo.Client
+	Registry       *registry.Client
+	MemcClient     *memcache.Client
 }
 
 // Run starts the server
@@ -58,7 +59,10 @@ func (s *Server) Run() error {
 			PermitWithoutStream: true,
 		}),
 		grpc.UnaryInterceptor(
-			otelgrpc.UnaryServerInterceptor(),
+			otelgrpc.UnaryServerInterceptor(
+				otelgrpc.WithTracerProvider(s.TracerProvider),
+				otelgrpc.WithPropagators(otel.GetTextMapPropagator()),
+			),
 		),
 	}
 

--- a/services/reservation/server.go
+++ b/services/reservation/server.go
@@ -10,17 +10,18 @@ import (
 	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
-	"hotelReservation/registry"
-	pb "hotelReservation/services/reservation/proto"
-	"hotelReservation/tls"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
+	"hotelReservation/registry"
+	pb "hotelReservation/services/reservation/proto"
+	"hotelReservation/tls"
 )
 
 const name = "srv-reservation"
@@ -31,13 +32,13 @@ type Server struct {
 
 	uuid string
 
-	Tracer      trace.Tracer
+	Tracer         trace.Tracer
 	TracerProvider trace.TracerProvider
-	Port        int
-	IpAddr      string
-	MongoClient *mongo.Client
-	Registry    *registry.Client
-	MemcClient  *memcache.Client
+	Port           int
+	IpAddr         string
+	MongoClient    *mongo.Client
+	Registry       *registry.Client
+	MemcClient     *memcache.Client
 }
 
 // Run starts the server
@@ -57,7 +58,10 @@ func (s *Server) Run() error {
 			PermitWithoutStream: true,
 		}),
 		grpc.UnaryInterceptor(
-			otelgrpc.UnaryServerInterceptor(),
+			otelgrpc.UnaryServerInterceptor(
+				otelgrpc.WithTracerProvider(s.TracerProvider),
+				otelgrpc.WithPropagators(otel.GetTextMapPropagator()),
+			),
 		),
 	}
 


### PR DESCRIPTION
## Summary
- refactor `dialer.Dial` to chain custom and default interceptors
- expose dialer options struct to collect interceptors

## Testing
- `go vet ./...` *(fails: zerolog `Msgf` formatting errors)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68495773aaf4832493205a63f6b39227